### PR TITLE
Allow an empty  `REPLACEMENTPATTERN` + minor cleanup

### DIFF
--- a/pdfreplacetxt.sh
+++ b/pdfreplacetxt.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-
 PROGNAME=${0##*/}
 STARTTIME=$(date +%s)
 
@@ -20,7 +18,7 @@ Function:
   to use open-ended regexes such as \"*. etc\" for a search patternn.
 
 Example:
-	pdfsed ebook.pdf \"09 October\" \"10 October\"
+  pdfsed ebook.pdf \"09 October\" \"10 October\"
 
 Author:
   Gerrit Hoekstra. You can contact me via https://github.com/gerritonagoodday
@@ -50,16 +48,15 @@ function doneit {
   fi
 }
 
+[[ $# -ne 3 ]] && Usage
 PDFFILE="${1}"
-[[ -z $PDFFILE ]] && Usage
+[[ -z "$PDFFILE" ]] && Usage
 SEARCHPATTERN="${2}"
-[[ -z $SEARCHPATTERN ]] && Usage
+[[ -z "$SEARCHPATTERN" ]] && Usage
 REPLACEMENTPATTERN="${3}"
-[[ -z $REPLACEMENTPATTERN ]] && Usage
 
 # Temp work files
-TMPFILE1=$(mktemp "/tmp/tmp.${PROGNAME}.$$.XXXXXX")
-#TMPFILE2=$(mktemp "/tmp/tmp.${PROGNAME}.$$.XXXXXX")
+TMPFILE1="$(mktemp --tmpdir "${PROGNAME}.$$.XXXXXX")"
 
 #============================================================================#
 # Set traps and signal BEGIN and END
@@ -67,7 +64,6 @@ TMPFILE1=$(mktemp "/tmp/tmp.${PROGNAME}.$$.XXXXXX")
 #============================================================================#
 function cleanup {
   rm "${TMPFILE1}" 2>/dev/null
-  #rm "${TMPFILE2}" 2>/dev/null
   ENDTIME=$(date +%s)
   elapsedseconds=$((ENDTIME-STARTTIME))
   s=$((elapsedseconds % 60))
@@ -80,10 +76,10 @@ function cleanup {
 for sig in KILL TERM INT EXIT; do trap 'cleanup $sig' "$sig" ; done
 
 info "Checking environment"
-PDFTK=`which pdftk 2>/dev/null`
+PDFTK="$(which pdftk 2>/dev/null)"
 [[ -z "$PDFTK" ]] && die "pdftk does not appear to be installed."
 info "Checking $PDFFILE"
-[[ ! -f $PDFFILE ]] && die "$PDFFILE does not exist"
+[[ ! -f "$PDFFILE" ]] && die "$PDFFILE does not exist"
 filetype=$(file -b "$PDFFILE")
 if [[ $filetype =~ ^PDF ]]; then
   info "$PDFFILE is a PDF file"
@@ -92,21 +88,19 @@ else
 fi
 
 info "Uncompressing $PDFFILE"
-pdftk "$PDFFILE" output $TMPFILE1 uncompress  > /dev/null 2>&1
+pdftk "$PDFFILE" output "$TMPFILE1" uncompress  > /dev/null 2>&1
 retcode=$?
 [[ $retcode -ne 0 ]] && die "pdftk returned error code $retcode"
 
 info "Replacing '$SEARCHPATTERN' with '$REPLACEMENTPATTERN' in $PDFFILE"
 # Fix patterns with deal with PDF formatting codes
-SEARCHPATTERN=$(echo $SEARCHPATTERN | sed -e 's/ /.*/g')
+SEARCHPATTERN="$(echo "$SEARCHPATTERN" | sed -e 's/ /.*/g')"
 # Deal with patterns that contains actual speech marks
-SEARCHPATTERN=$(echo $SEARCHPATTERN | sed -e "s|'|\x27|g" | sed -e 's/"/\x22/g')
-REPLACEMENTPATTERN=$(echo $REPLACEMENTPATTERN | sed -e "s|'|\x27|g" | sed -e 's/"/\x22/g')
-sed -e "s|${SEARCHPATTERN}|${REPLACEMENTPATTERN}|g" -i $TMPFILE1
+SEARCHPATTERN="$(echo "$SEARCHPATTERN" | sed -e "s|'|\x27|g" | sed -e 's/"/\x22/g')"
+REPLACEMENTPATTERN="$(echo "$REPLACEMENTPATTERN" | sed -e "s|'|\x27|g" | sed -e 's/"/\x22/g')"
+sed -e "s|${SEARCHPATTERN}|${REPLACEMENTPATTERN}|g" -i "$TMPFILE1"
 
 info "Re-Compressing $PDFFILE"
-pdftk $TMPFILE1 output "$PDFFILE" compress  > /dev/null 2>&1
+pdftk "$TMPFILE1" output "$PDFFILE" compress > /dev/null 2>&1
 retcode=$?
 [[ $retcode -ne 0 ]] && die "pdftk returned error code $retcode"
-
-

--- a/pdfreplacetxt.sh
+++ b/pdfreplacetxt.sh
@@ -18,7 +18,7 @@ Function:
   to use open-ended regexes such as \"*. etc\" for a search patternn.
 
 Example:
-  pdfsed ebook.pdf \"09 October\" \"10 October\"
+  ${0##*/} ebook.pdf \"09 October\" \"10 October\"
 
 Author:
   Gerrit Hoekstra. You can contact me via https://github.com/gerritonagoodday


### PR DESCRIPTION
Motivatioin:

`pdfreplacetxt.sh` currently doesn't accept an empty `REPLACEMENTPATTERN`.
An empty `REPLACEMENTPATTERN` can be useful when a user wants to remove certain text from a PDF file.

Modifications:

- Updated the argument validation logic so it doesn't exit when a user specified an empty `REPLACEMENTPATTERN`.
- Added double quotes when accessing some variables for correctness.
- Made `mktemp` respect `TMPDIR` environment variable.
- Minor whitespace cleanup

Result:

- A user can remove a certain text from a PDF file.
- A user can specify a PDF file whose path contains whitespaces.
- A user can specify the search or replacement pattern that contains consecutive whitespaces.
- A user can run the script with a custom `TMPDIR` environment variable.